### PR TITLE
detect machine arch

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -7,7 +7,8 @@ install_aws-iam-authenticator() {
   local install_type=$1
   local version=$2
   local install_path=$3
-  local platform="$(uname | tr '[:upper:]' '[:lower:]')_amd64"
+  local arch=$(uname -m | sed 's/aarch64/arm64/g; s/x86_64/amd64/g')
+  local platform="$(uname | tr '[:upper:]' '[:lower:]')_${arch}"
   local bin_install_path="$install_path/bin"
   local binary_path="$bin_install_path/aws-iam-authenticator"
   local download_url=$(get_download_url $version $platform)


### PR DESCRIPTION
The current version hardcodes to `amd64` CPU. This PR detects the CPU type via `uname -m`  so this would work with OS running on arm64 CPU such as the Apple M1/M2 Macs and Linux on ARM64